### PR TITLE
Specmatic Core Uber Command branch integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <kotlin.version>2.3.0</kotlin.version>
         <maven.compiler>17</maven.compiler>
-        <specmatic.version>2.37.2</specmatic.version>
+        <specmatic.version>2.37.4-SNAPSHOT</specmatic.version>
         <spring.boot.version>3.5.9</spring.boot.version>
         <cxf.version>4.1.4</cxf.version>
     </properties>

--- a/specmatic.yaml
+++ b/specmatic.yaml
@@ -3,9 +3,12 @@ contracts:
   - git:
       url: https://github.com/specmatic/specmatic-order-contracts.git
     provides:
-      - io/specmatic/examples/store/openapi/api_order_v5.yaml
+      - specs:
+          - io/specmatic/examples/store/openapi/api_order_v5.yaml
+        baseUrl: http://localhost:8090
   - consumes:
-      - wsdls/inventory.wsdl
+    - wsdls/inventory.wsdl
+
 report:
   types:
     APICoverage:
@@ -14,3 +17,7 @@ report:
           minThresholdPercentage: 65
           maxMissedEndpointsInSpec: 4
           enforce: true
+test:
+  resiliencyTests:
+    enable: all
+  filter: "PATH!='/internal/metrics'"

--- a/src/test/java/com/store/ContractTest.java
+++ b/src/test/java/com/store/ContractTest.java
@@ -5,34 +5,21 @@ import io.specmatic.stub.ContractStub;
 import io.specmatic.test.SpecmaticContractTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.springframework.boot.SpringApplication;
-import org.springframework.context.ConfigurableApplicationContext;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import static io.specmatic.stub.API.createStub;
 
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ContractTest implements SpecmaticContractTest {
-    private static ConfigurableApplicationContext context;
-    private static final String EXCLUDED_ENDPOINTS = "'/internal/metrics'";
     private static ContractStub stub = null;
-
     @BeforeAll
-    public static void setUp() {
-        System.setProperty("host", "localhost");
-        System.setProperty("port", "8090");
-        System.setProperty("SPECMATIC_GENERATIVE_TESTS", "true");
-        System.setProperty("SPECMATIC_TEST_PARALLELISM", "auto");
-        System.setProperty("filter", String.format("PATH!=%s", EXCLUDED_ENDPOINTS));
-        System.setProperty("INVENTORY_API_URL", "http://localhost:9000/ws");
-        System.out.println("Running contract tests using Specmatic against application at localhost:8080");
-
+    public static void setup() throws Exception {
         DB.INSTANCE.resetDB();
-
         stub = createStub("localhost", 9000);
-
-        context = SpringApplication.run(Application.class);
     }
 
     @AfterAll
@@ -40,7 +27,5 @@ public class ContractTest implements SpecmaticContractTest {
         if(stub != null) {
             stub.close();
         }
-
-        context.close();
     }
 }

--- a/src/test/java/com/store/ContractTestUsingCLITest.java
+++ b/src/test/java/com/store/ContractTestUsingCLITest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @EnabledIf(value = "isNonCIOrLinux", disabledReason = "Run only on Linux in CI; all platforms allowed locally")
@@ -48,14 +49,12 @@ public class ContractTestUsingCLITest {
     }
 
     private static SpecmaticExecutor createStub() {
-        List<String> args = asList("virtualize", "--port=" + HTTP_STUB_PORT);
-        Map<String, String> env = Map.of("SOME_ENV", "value");
-        return new SpecmaticExecutor(args, env);
+        List<String> args = asList("virtualize");
+        return new SpecmaticExecutor(args, emptyMap());
     }
 
     private static SpecmaticExecutor createTest() {
-        List<String> args = asList("test", "--host=" + APPLICATION_HOST, "--port=" + APPLICATION_PORT, "--filter=PATH!=" + EXCLUDED_ENDPOINTS);
-        Map<String, String> env = Map.of("SPECMATIC_GENERATIVE_TESTS", "true", "SPECMATIC_TEST_PARALLELISM", "auto");
-        return new SpecmaticExecutor(args, env);
+        List<String> args = asList("test");
+        return new SpecmaticExecutor(args, emptyMap());
     }
 }

--- a/src/test/java/com/store/ContractTestUsingTestContainerTest.java
+++ b/src/test/java/com/store/ContractTestUsingTestContainerTest.java
@@ -36,10 +36,8 @@ public class ContractTestUsingTestContainerTest {
 
         System.out.println("Using docker host address: " + dockerHostAddress);
         testContainer = new GenericContainer<>("specmatic/specmatic:latest")
-                .withCommand("test", "--host=" + APPLICATION_HOST, "--port=" + APPLICATION_PORT, "--filter=PATH!=" + EXCLUDED_ENDPOINTS)
+                .withCommand("test")
 //                .withImagePullPolicy(PullPolicy.alwaysPull())
-                .withEnv("SPECMATIC_GENERATIVE_TESTS", "true")
-                .withEnv("SPECMATIC_TEST_PARALLELISM", "auto")
                 .withFileSystemBind("./specmatic.yaml", "/usr/src/app/specmatic.yaml", BindMode.READ_ONLY)
                 .withFileSystemBind("./build/reports/specmatic", "/usr/src/app/build/reports/specmatic", BindMode.READ_WRITE)
                 // For Docker Desktop on Windows and Mac, "host.docker.internal" is used to refer to the host machine.
@@ -53,8 +51,7 @@ public class ContractTestUsingTestContainerTest {
         stubContainer = new GenericContainer<>("specmatic/specmatic")
 //                .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withCommand(
-                        "virtualize",
-                        "--port=" + HTTP_STUB_PORT
+                        "virtualize"
                 )
                 .withCreateContainerCmdModifier(cmd -> {
                     if (cmd.getHostConfig() != null) {


### PR DESCRIPTION
Update specmatic config to define test base url, resiliencyTests and fiters so that we don't have to defined these in the individual contract test classes.
Removed test and stub host, port, SPECMATIC_GENERATIVE_TESTS configuration from all contract tests.